### PR TITLE
Docs: agent change report (2025-08-24)

### DIFF
--- a/docs/recovery/agent-change-report-20250824.md
+++ b/docs/recovery/agent-change-report-20250824.md
@@ -1,0 +1,18 @@
+# Agent change report (aligned to VS Code Local History)
+
+- Source: docs/recovery/agent-edits-log.txt
+- Date: 2025-08-24 (session)
+
+## Restored client files (from Local History)
+- client/src/components/TransactionSheet.tsx
+- client/src/hooks/useApiTransactions.ts
+- client/src/index.css
+- client/src/pages/Transactions.tsx
+
+## Focus files and latest agent-edit timestamps
+- Revoclone/client/src/pages/Transactions.tsx: latest_ts=(none), status=present, lines=166
+- Revoclone/client/src/components/TransactionSheet.tsx: latest_ts=(none), status=present, lines=184
+- Revoclone/client/src/components/MapWidget.tsx: latest_ts=(none), status=missing, lines=0
+- Revoclone/client/src/constants/locations.ts: latest_ts=(none), status=missing, lines=0
+
+## Top files with agent history (latest timestamps)


### PR DESCRIPTION
Adds docs/recovery/agent-change-report-20250824.md summarizing files touched by the agent per Local History, with focus on Transactions, TransactionSheet, MapWidget, and locations.